### PR TITLE
fix: math funcs, bumped constantine to 976c8bb

### DIFF
--- a/eth_verkle/math.nim
+++ b/eth_verkle/math.nim
@@ -35,16 +35,12 @@ IdentityPoint.y.setOne()
 IdentityPoint.z.setOne()
 
 var ipaConfig: IPASettings
-var ipaTranscript: IpaTranscript[sha256, 32]
-discard ipaConfig.genIPAConfig(ipaTranscript)
-
-var basisPoints : array[256, EC_P]
-basisPoints.generate_random_points(ipaTranscript, 256)
+discard ipaConfig.genIPAConfig()
 
 
 proc ipaCommitToPoly*(poly: array[256, Field]): Point =
   var comm: Point
-  comm.pedersen_commit_varbasis(basisPoints, basisPoints.len, poly, poly.len)
+  comm.pedersen_commit_varbasis(ipaConfig.SRS, ipaConfig.SRS.len, poly, poly.len)
   return comm
 
 


### PR DESCRIPTION
Bumped Constantine [Master] to latest commit, and made necessary fixes in `generate_random_points()`.
Tests seem to pass in Nim `1.6.18`
<img width="823" alt="image" src="https://github.com/status-im/nim-eth-verkle/assets/80243668/675e1b43-487d-496a-8e13-ee1537453e94">

